### PR TITLE
Configurable default lock_ttl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         database: [mysql, postgresql]
 
     services:

--- a/README.rst
+++ b/README.rst
@@ -99,3 +99,5 @@ There are also the following options you can specify in the project `settings.py
 
 - *DATABASE_LOCKS_STATUS_FILE*: file that will be updated with the lock status (default `None`). Useful when you have multiple shared-lock processes, to quickly inspect which one has the lock.
 - *DATABASE_LOCKS_ENABLED*: set to `False` to globally disable locks (default `True`)
+- *DATABASE_LOCKS_DEFAULT_TTL*: global lock TTL value (default `10`) which is ignored when `lock_ttl` is specified
+- *DATABASE_LOCKS_DEFAULT_TTL_RENEW*: number of seconds to renew lock before TTL expires (default `2`)

--- a/README.rst
+++ b/README.rst
@@ -101,3 +101,33 @@ There are also the following options you can specify in the project `settings.py
 - *DATABASE_LOCKS_ENABLED*: set to `False` to globally disable locks (default `True`)
 - *DATABASE_LOCKS_DEFAULT_TTL*: global lock TTL value (default `10`) which is ignored when `lock_ttl` is specified
 - *DATABASE_LOCKS_DEFAULT_TTL_RENEW*: number of seconds to renew lock before TTL expires (default `2`)
+
+
+Testing
+-------
+
+Tox is used by the Github Action to test several python and django versions, with both MySQL and Postgres.
+
+To quickly test locally, kick off a MySQL and/or Postgres docker container:
+
+```
+docker run -d --name locks-test \
+           -p 8877:3306 \
+           -e MYSQL_ROOT_PASSWORD=root \
+           mysql:5.7
+```
+
+```
+docker run -d --name locks-test-psql \
+           -p 8878:5432 \
+           -e POSTGRES_PASSWORD=postgres \
+           postgres:10
+```
+
+List available environments with `tox -l` and then run the one you want/have:
+
+```
+tox -e py39-dj32-mysql
+# or
+tox -e py39-dj32-postgresql -e py39-dj32-mysql
+```

--- a/database_locks/apps.py
+++ b/database_locks/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 from django.conf import settings
 
-APP_SETTINGS = dict(STATUS_FILE=None, ENABLED=True)
+APP_SETTINGS = dict(STATUS_FILE=None, ENABLED=True, DEFAULT_TTL=10, DEFAULT_TTL_RENEW=2)
 
 
 class DBLocksConfig(AppConfig):

--- a/database_locks/locks.py
+++ b/database_locks/locks.py
@@ -261,4 +261,3 @@ def _status_file(message):
         logger.exception(
             'failed to update lock status file %s', settings.DATABASE_LOCKS_STATUS_FILE
         )
-

--- a/database_locks/locks.py
+++ b/database_locks/locks.py
@@ -16,17 +16,19 @@ from django.core.management.base import BaseCommand
 
 
 logger = logging.getLogger(__name__)
+NOTSET = object()
 
 
 @contextmanager
 def lock(
     lock_name,
     timeout=0,
-    lock_ttl=10,
+    lock_ttl=NOTSET,
     locked_by=None,
     auto_renew=True,
     retry=0.5,
     lost_lock_cb=None,
+    lock_ttl_renew=NOTSET,
 ):
     """
     :param lock_name: unique name in DB for this function
@@ -37,6 +39,7 @@ def lock(
                        auto_renew thread will raise KeyboardInterrupt on the main thread in case re-acquiring fails
     :param retry: retry every `retry` seconds acquiring until successful. set to None or 0 to disable.
     :param lost_lock_cb: callback function when lock is lost (when re-acquiring). defaults to raising LockException
+    :param lock_ttl_renew: number of seconds to renew before lock_ttl expires
     :return:
     """
     # TODO migrate to contextlib.ContextDecorator once only py3 is used
@@ -56,6 +59,11 @@ def lock(
         )
         yield
         return
+
+    if lock_ttl is NOTSET:
+        lock_ttl = settings.DATABASE_LOCKS_DEFAULT_TTL
+    if lock_ttl_renew is NOTSET:
+        lock_ttl_renew = settings.DATABASE_LOCKS_DEFAULT_TTL_RENEW
 
     logger.info('acquiring lock %s' % lock_name)
     lock = DBLock(lock_name, locked_by=locked_by)
@@ -77,7 +85,7 @@ def lock(
 
     renew_thread = None
     if auto_renew:
-        renew_thread = RenewThread(lock, lock_ttl)
+        renew_thread = RenewThread(lock, lock_ttl, lock_ttl_renew)
         renew_thread.start()
 
     _status_file('2')
@@ -204,15 +212,13 @@ class DBLock:
 
 
 class RenewThread(threading.Thread):
-    EARLY_TICK = 1
-
-    def __init__(self, lock_obj, ttl):
+    def __init__(self, lock_obj, ttl, early_tick):
         super(RenewThread, self).__init__()
 
         self.__lock = lock_obj
         self.__ttl = ttl
-        # renew 1 second before TTL
-        self.__wait = max(ttl - self.EARLY_TICK, 1)
+        # renew EARLY_TICK seconds before TTL
+        self.__wait = max(ttl - early_tick, 1)
 
         self.__stopped = threading.Event()
         self.daemon = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,3 +46,6 @@ max-line-length = 88
 
 [coverage:run]
 source = database_locks
+
+[coverage:report]
+show_missing = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 envlist =
     flake8
-    py{37,38}-dj{22,30}-{postgresql,mysql}
+    py{37,38,39}-dj{22,30,32}-{postgresql,mysql}
 
 [testenv]
 deps =
     dj22: Django==2.2.*
     dj30: Django==3.0.*
+    dj32: Django==3.2.*
     postgresql: psycopg2-binary
     mysql: mysqlclient
     coverage


### PR DESCRIPTION
Allow default values of `lock_ttl` and `EARLY_TICK` to be specified in the project settings